### PR TITLE
Fix issues reported by scan-build, cppcheck, coverage testing

### DIFF
--- a/src/authentication_2.c
+++ b/src/authentication_2.c
@@ -39,7 +39,7 @@ unpack_authenticated_variable (const auth_data_t *auth_data, timestamp_t *timest
   if (auth_data->auth_msg_size < sizeof (auth_info_t))
     {
       prlog (PR_ERR, "Buffer too small for an auth2 header - got %lu bytes.\n",
-             auth_data->auth_msg_size);
+             (unsigned long) auth_data->auth_msg_size);
       return SV_BUF_INSUFFICIENT_DATA;
     }
 
@@ -67,7 +67,8 @@ unpack_authenticated_variable (const auth_data_t *auth_data, timestamp_t *timest
    */
   if (da_length <= sizeof (auth_cert_t))
     {
-      prlog (PR_ERR, "da_length in auth header too short for fixed data - %lu bytes\n", da_length);
+      prlog (PR_ERR, "da_length in auth header too short for fixed data - %lu bytes\n",
+             (unsigned long) da_length);
       return SV_AUTH_SIZE_INVALID;
     }
 

--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -379,6 +379,19 @@ pkcs7_signed_hash_verify (crypto_pkcs7_t *pkcs7, crypto_x509_t *x509, unsigned c
 
   /* verify on all signatures in pkcs7 */
   num_signers = sk_PKCS7_SIGNER_INFO_num (pkcs7->signer_info);
+  if (num_signers == 0)
+    {
+      prlog (PR_ERR, "ERROR: no signers to verify");
+      rc = SV_PKCS7_ERROR;
+      goto out;
+    }
+  else if (num_signers < 0)
+    {
+      prlog(PR_ERR, "ERROR: pkcs7->signer_info was NULL");
+      rc = SV_PKCS7_ERROR;
+      goto out;
+    }
+
   for (int s = 0; s < num_signers; s++)
     {
       /* make sure we can get the signature data */

--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -546,7 +546,7 @@ pkcs7_generate_w_signature (unsigned char **pkcs7, size_t *pkcs7_size,
   EVP_PKEY *evp_pkey = NULL;
   const EVP_MD *evp_md = NULL;
   crypto_x509_t *x509 = NULL;
-  size_t pkcs7_out_len;
+  long pkcs7_out_len;
   unsigned char *key = NULL, *keyTmp, *crt = NULL, *out_bio_der = NULL;
   char *unnecessary_hdr = NULL, *unnecessary_name = NULL;
   long int keySize, crtSize;

--- a/src/esl.c
+++ b/src/esl.c
@@ -70,7 +70,7 @@ next_esl_from_buffer (const uint8_t *buf, size_t buf_size, const uint8_t **esl,
   if (buf == NULL || esl == NULL || esl_size == NULL)
     return SV_BUF_INSUFFICIENT_DATA;
 
-  if (*esl != NULL && ((*esl < buf) && (*esl > (buf + buf_size))))
+  if (*esl != NULL && ((*esl < buf) || (*esl > (buf + buf_size))))
     return SV_BUF_INSUFFICIENT_DATA;
 
   first = (*esl == NULL);

--- a/src/esl.c
+++ b/src/esl.c
@@ -91,7 +91,7 @@ next_esl_from_buffer (const uint8_t *buf, size_t buf_size, const uint8_t **esl,
   if (left < sizeof (sv_esl_t))
     {
       prlog (PR_ERR, "Not enough space left for an ESL when unpacking buffer: %lu bytes remain\n",
-             left);
+             (unsigned long) left);
       return SV_BUF_INSUFFICIENT_DATA;
     }
 
@@ -102,13 +102,13 @@ next_esl_from_buffer (const uint8_t *buf, size_t buf_size, const uint8_t **esl,
   if (claimed_size < sizeof (sv_esl_t))
     {
       prlog (PR_ERR, "ESL's claimed size is too small for the fixed contents: %lu bytes\n",
-             claimed_size);
+             (unsigned long) claimed_size);
       return SV_ESL_SIZE_INVALID;
     }
   else if (claimed_size > left)
     {
       prlog (PR_ERR, "ESL's claimed size is bigger than the data left in the buffer: %lu vs %lu\n",
-             claimed_size, left);
+             (unsigned long) claimed_size, (unsigned long) left);
       return SV_BUF_INSUFFICIENT_DATA;
     }
 
@@ -153,13 +153,13 @@ next_esl_from_buffer (const uint8_t *buf, size_t buf_size, const uint8_t **esl,
   if (claimed_size < sizeof (sv_esl_t))
     {
       prlog (PR_ERR, "ESL's claimed size is too small for the fixed contents: %lu bytes\n",
-             claimed_size);
+             (unsigned long) claimed_size);
       return SV_ESL_SIZE_INVALID;
     }
   else if (claimed_size > left)
     {
       prlog (PR_ERR, "ESL's claimed size is bigger than the data left in the buffer: %lu vs %lu\n",
-             claimed_size, left);
+             (unsigned long) claimed_size, (unsigned long) left);
       return SV_BUF_INSUFFICIENT_DATA;
     }
 

--- a/src/esl.c
+++ b/src/esl.c
@@ -214,7 +214,7 @@ next_esd_from_esl (const uint8_t *esl, const uint8_t **esd_data, size_t *esd_dat
   if (esd_data == NULL || esd_data_size == NULL)
     return SV_BUF_INSUFFICIENT_DATA;
 
-  if (*esd_data != NULL && ((*esd_data < esl) && (*esd_data > (esl + esl_size))))
+  if (*esd_data != NULL && ((*esd_data < esl) || (*esd_data > (esl + esl_size))))
     return SV_BUF_INSUFFICIENT_DATA;
 
   first = (*esd_data == NULL);

--- a/src/pseries.c
+++ b/src/pseries.c
@@ -142,7 +142,8 @@ convert_to_ucs2 (const update_req_t *update_req, uint16_t **name)
 {
   if (update_req->label_size % 2 != 0)
     {
-      prlog (PR_ERR, "label has an odd number of bytes: %lu\n", update_req->label_size);
+      prlog (PR_ERR, "label has an odd number of bytes: %lu\n",
+             (unsigned long) update_req->label_size);
       return SV_LABEL_IS_NOT_WIDE_CHARACTERS;
     }
 

--- a/src/update.c
+++ b/src/update.c
@@ -337,7 +337,7 @@ pseries_apply_update (const auth_data_t *auth_data, uint8_t **new_esl_data,
       rc = append_update (auth_data, esl_data, esl_data_size, new_esl_data, new_esl_data_size);
       if (rc == SV_SUCCESS)
         {
-          if (is_after (&update_time, auth_data->current_time))
+          if (auth_data->current_time == NULL || is_after (&update_time, auth_data->current_time))
             *new_time = update_time;
           else
             *new_time = *auth_data->current_time;

--- a/test/test_auth2.c
+++ b/test/test_auth2.c
@@ -92,7 +92,7 @@ main (int argc, char **argv)
    * 6b:bb:47:0b:52:59:f6:9e:02:07:94:39:93:ea:4b:25:8b:51:0e:df:c5:1f:
    * a5:bd:ba:df:9f:ba:92:4e:4b:82
    */
-  if (rc == SV_SUCCESS && hash != NULL && hash[0] == 0x6b && hash[1] == 0xbb &&
+  if (rc == SV_SUCCESS && hash[0] == 0x6b && hash[1] == 0xbb &&
       hash[30] == 0x4b && hash[31] == 0x82)
     printf ("Test case-5 : PASSED\n");
   else


### PR DESCRIPTION
Fix two edge-case errors detected by scan-build. Both might have usage implications, so they should be reviewed to ensure they maintain expected behavior. See each commit's description for further detail.

Both of the issues were in code containing a lot of conditionals, some nested. Would recommend refactoring this code in the future to reduce the conditional complexity, ideally making it less prone to these types of errors.