### PR TITLE
libstb-secvar: trustedcadb variable allow only CA certificates

### DIFF
--- a/include/libstb-secvar-errors.h
+++ b/include/libstb-secvar-errors.h
@@ -49,6 +49,7 @@ enum _sv_errors
    * a set of ESLs containing RSA-2048/4096 certs.
    */
   SV_INVALID_KEK_UPDATE,
+  SV_INVALID_TRUSTEDCADB_UPDATE,
 
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
   /* currently unused, untested and broken auth file write support */

--- a/include/secvar/crypto.h
+++ b/include/secvar/crypto.h
@@ -33,6 +33,7 @@ typedef int (*crypto_x509_sig_len) (crypto_x509_t *, size_t *);
 typedef int (*crypto_x509_is_pkcs1_sha256) (crypto_x509_t *);
 typedef crypto_x509_t *(*crypto_x509_parse_der_cert) (const unsigned char *, size_t);
 typedef void (*crypto_str_error) (int, char *, size_t);
+typedef bool (*crypto_x509_cert_is_CA) (crypto_x509_t *);
 
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
 typedef void (*crypto_x509_short_info) (crypto_x509_t *, char *, size_t);
@@ -105,6 +106,7 @@ struct x509_func
   crypto_x509_sig_len get_sig_len;
   crypto_x509_parse_der_cert parse_der;
   crypto_str_error error_string;
+  crypto_x509_cert_is_CA is_CA;
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
   crypto_x509_short_info get_short_info;
   crypto_x509_cert_long_desc get_long_desc;
@@ -131,6 +133,7 @@ typedef void (*release_x509_cert) (crypto_x509_t *);
 typedef void (*release_pkcs7_cert) (crypto_pkcs7_t *);
 typedef int (*verify_pkcs7) (crypto_pkcs7_t *, crypto_x509_t *, unsigned char *, int);
 typedef int (*pkcs7_md) (crypto_pkcs7_t *);
+typedef bool (*validate_x509_cert_CA) (crypto_x509_t *);
 
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
 typedef int (*generate_pkcs7_sig) (uint8_t *, size_t, uint8_t **, uint8_t **, size_t, uint8_t **, size_t *);
@@ -157,6 +160,7 @@ struct crypto
   release_pkcs7_cert release_pkcs7_certificate;
   verify_pkcs7 verify_pkcs7_signature;
   pkcs7_md pkcs7_md_is_sha256;
+  validate_x509_cert_CA validate_x509_certificate_CA;
   crypto_str_error error_string;
 };
 

--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <openssl/pkcs7.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 #include <openssl/objects.h>
 #include <openssl/ossl_typ.h>
 #include <openssl/asn1.h>
@@ -19,6 +20,15 @@
 #include "libstb-secvar-errors.h"
 
 /* X509 */
+
+static bool
+x509_is_CA (crypto_x509_t *x509)
+{
+  if (X509_check_ca (x509) == 1)
+    return true;
+
+  return false;
+}
 
 static int
 x509_get_der_len (crypto_x509_t *x509, size_t *size)
@@ -878,6 +888,7 @@ x509_func_t crypto_x509 = { .get_der_len = x509_get_der_len,
                             .get_sig_len = x509_get_sig_len,
                             .parse_der = x509_parse_der,
                             .error_string = error_string,
+                            .is_CA = x509_is_CA,
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
                             .get_short_info = x509_get_short_info,
                             .md_is_sha256 = x509_md_is_sha256,

--- a/src/crypto_util.c
+++ b/src/crypto_util.c
@@ -7,6 +7,12 @@
 #include "secvar/crypto.h"
 #include "libstb-secvar-errors.h"
 
+static bool
+validate_x509_certificate_CA (crypto_x509_t *x509)
+{
+  return crypto_x509.is_CA (x509);
+}
+
 static int
 get_x509_certificate (const uint8_t *cert_data, size_t cert_data_size, crypto_x509_t **x509)
 {
@@ -241,5 +247,6 @@ crypto_func_t crypto = { .generate_md_hash = generate_md_hash,
                          .release_x509_certificate = release_x509_certificate,
                          .verify_pkcs7_signature = verify_pkcs7_signature,
                          .pkcs7_md_is_sha256 = pkcs7_md_is_sha256,
+                         .validate_x509_certificate_CA = validate_x509_certificate_CA,
                          .error_string = error_string
                          };


### PR DESCRIPTION
checked to have basicConstraints CA:TRUE for any certificate added to trustedcadb, else returned as invalid certificate.