### PR TITLE
crypto: changing the name validate_x509_certificate_CA

### DIFF
--- a/include/secvar/crypto.h
+++ b/include/secvar/crypto.h
@@ -133,7 +133,7 @@ typedef void (*release_x509_cert) (crypto_x509_t *);
 typedef void (*release_pkcs7_cert) (crypto_pkcs7_t *);
 typedef int (*verify_pkcs7) (crypto_pkcs7_t *, crypto_x509_t *, unsigned char *, int);
 typedef int (*pkcs7_md) (crypto_pkcs7_t *);
-typedef bool (*validate_x509_cert_CA) (crypto_x509_t *);
+typedef bool (*x509_cert_is_CA) (crypto_x509_t *);
 
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
 typedef int (*generate_pkcs7_sig) (uint8_t *, size_t, uint8_t **, uint8_t **, size_t, uint8_t **, size_t *);
@@ -160,7 +160,7 @@ struct crypto
   release_pkcs7_cert release_pkcs7_certificate;
   verify_pkcs7 verify_pkcs7_signature;
   pkcs7_md pkcs7_md_is_sha256;
-  validate_x509_cert_CA validate_x509_certificate_CA;
+  x509_cert_is_CA x509_is_CA;
   crypto_str_error error_string;
 };
 

--- a/src/crypto_util.c
+++ b/src/crypto_util.c
@@ -8,7 +8,7 @@
 #include "libstb-secvar-errors.h"
 
 static bool
-validate_x509_certificate_CA (crypto_x509_t *x509)
+x509_is_CA (crypto_x509_t *x509)
 {
   return crypto_x509.is_CA (x509);
 }
@@ -247,6 +247,6 @@ crypto_func_t crypto = { .generate_md_hash = generate_md_hash,
                          .release_x509_certificate = release_x509_certificate,
                          .verify_pkcs7_signature = verify_pkcs7_signature,
                          .pkcs7_md_is_sha256 = pkcs7_md_is_sha256,
-                         .validate_x509_certificate_CA = validate_x509_certificate_CA,
+                         .x509_is_CA = x509_is_CA,
                          .error_string = error_string
                          };

--- a/src/pseries.c
+++ b/src/pseries.c
@@ -132,7 +132,7 @@ cert_parses_as_good_RSA (const uint8_t *cert_data, size_t cert_size, const bool 
       return false;
     }
 
-  if (check_CA && !crypto.validate_x509_certificate_CA (cert))
+  if (check_CA && !crypto.x509_is_CA (cert))
     {
       prlog (PR_ERR, "it is not CA certificate\n");
       crypto.release_x509_certificate (cert);


### PR DESCRIPTION
validate_x509_certificate_CA name making confustion to the functionality. So, changing the name from validate_x509_certificate_CA to x509_is_CA