### PR TITLE
Rewrite Makefile Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-lib
-*.o
-*.so
-*.d
-*.a
-test_esl
-test_auth2
-test_update
-test_pseries
-test_phyp
+lib/
+obj/
+test/bin/

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,10 @@ $(LIB_DIR)/libstb-secvar-openssl.so: $(OBJS)
 	@mkdir -p $(LIB_DIR)
 	$(LD) $(_LDFLAGS) -shared $^ -o $@
 
-check: $(LIB_DIR)/libstb-secvar-openssl.a test
+tests: $(LIB_DIR)/libstb-secvar-openssl.a
+	@$(MAKE) -C $(TEST_DIR)
+
+check: $(LIB_DIR)/libstb-secvar-openssl.a
 	@$(MAKE) -C $(TEST_DIR) check
 
 cppcheck:
@@ -77,4 +80,4 @@ clean:
 	@$(MAKE) -C $(TEST_DIR) clean
 	rm -rf $(OBJ_DIR) $(LIB_DIR)
 
-.PHONY: all check cppcheck cppcheck-be clean
+.PHONY: all check cppcheck cppcheck-be clean tests

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ $(LIB_DIR)/libstb-secvar-openssl.so: $(OBJS)
 	@mkdir -p $(LIB_DIR)
 	$(LD) $(_LDFLAGS) -shared $^ -o $@
 
-check: $(LIB_DIR)/libstb-secvar-openssl.so test
+check: $(LIB_DIR)/libstb-secvar-openssl.a test
 	@$(MAKE) -C $(TEST_DIR) check
 
 cppcheck:

--- a/Makefile
+++ b/Makefile
@@ -28,35 +28,33 @@ ifeq ($(strip $(CRYPTO_READ_ONLY)), 0)
   _CFLAGS += -DSECVAR_CRYPTO_WRITE_FUNC
 endif
 
+SRCS = esl.c \
+       authentication_2.c \
+       update.c \
+       pseries.c \
+       crypto_util.c \
+       phyp.c
 
-SRCS = $(SRC_DIR)/esl.c \
-       $(SRC_DIR)/authentication_2.c \
-       $(SRC_DIR)/update.c \
-       $(SRC_DIR)/pseries.c \
-       $(SRC_DIR)/phyp.c
+SRCS += crypto_openssl.c
 
-OPENSSL_SRCS = $(SRCS) \
-               $(SRC_DIR)/crypto_openssl.c \
-               $(SRC_DIR)/crypto_util.c
+SRCS := $(addprefix $(SRC_DIR)/,$(SRCS))
 
-OPENSSL_OBJS = $(SRCS:.c=.openssl.o) $(OPENSSL_SRCS:.c=.openssl.o)
+OBJS = $(SRCS:.c=.o)
 _CFLAGS += $(CFLAGS) $(INCLUDE)
 _LDFLAGS += $(LDFLAGS)
 
 all: $(LIB_DIR)/libstb-secvar-openssl.a $(LIB_DIR)/libstb-secvar-openssl.so
 
--include $(OPENSSL_OBJS:.o=.d)
+-include $(OBJS:.o=.d)
 
 %.o: %.c
 	$(CC) $(_CFLAGS) $< -o $@ -c
-%.openssl.o: %.c
-	$(CC) $(_CFLAGS) $< -o $@ -c
 
-$(LIB_DIR)/libstb-secvar-openssl.a: $(OPENSSL_OBJS)
+$(LIB_DIR)/libstb-secvar-openssl.a: $(OBJS)
 	@mkdir -p $(LIB_DIR)
 	$(AR) -rcs $@ $^ $(_LDFLAGS)
 
-$(LIB_DIR)/libstb-secvar-openssl.so: $(OPENSSL_OBJS)
+$(LIB_DIR)/libstb-secvar-openssl.so: $(OBJS)
 	@mkdir -p $(LIB_DIR)
 	$(LD) $(_LDFLAGS) -shared $^ -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CFLAGS =
 LDFLAGS =
 
 SRC_DIR = ./src
+OBJ_DIR = ./obj
 LIB_DIR = ./lib
 TEST_DIR = ./test
 
@@ -39,7 +40,7 @@ SRCS += crypto_openssl.c
 
 SRCS := $(addprefix $(SRC_DIR)/,$(SRCS))
 
-OBJS = $(SRCS:.c=.o)
+OBJS = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRCS))
 _CFLAGS += $(CFLAGS) $(INCLUDE)
 _LDFLAGS += $(LDFLAGS)
 
@@ -47,7 +48,8 @@ all: $(LIB_DIR)/libstb-secvar-openssl.a $(LIB_DIR)/libstb-secvar-openssl.so
 
 -include $(OBJS:.o=.d)
 
-%.o: %.c
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	@mkdir -p $(OBJ_DIR)
 	$(CC) $(_CFLAGS) $< -o $@ -c
 
 $(LIB_DIR)/libstb-secvar-openssl.a: $(OBJS)
@@ -73,7 +75,6 @@ cppcheck-be:
 
 clean:
 	@$(MAKE) -C $(TEST_DIR) clean
-	find $(SRC_DIR) -name "*.[od]" -delete
-	rm -rf $(LIB_DIR)
+	rm -rf $(OBJ_DIR) $(LIB_DIR)
 
 .PHONY: all check cppcheck cppcheck-be clean

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,6 +29,10 @@ check: $(patsubst test_%.c,%-check,$(TEST_SRCS))
 %-check: $(BIN_DIR)/test_%
 	@$<
 
+$(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
+	@mkdir -p $(BIN_DIR)
+	$(CC) -o $@ $(_LDFLAGS) $(_CFLAGS) $^
+
 cppcheck:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \
 	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(TEST_SRCS) $(INCLUDE)
@@ -36,10 +40,6 @@ cppcheck:
 cppcheck-be:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \
 	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(TEST_SRCS) $(INCLUDE)
-
-$(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
-	@mkdir -p $(BIN_DIR)
-	$(CC) -o $@ $(_LDFLAGS) $(_CFLAGS) $^
 
 clean:
 	rm -rf $(BIN_DIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,8 +10,6 @@ SRC_DIR = ../src
 BIN_DIR =./bin
 LIB_DIR =../lib
 
-STATIC_LIB = 0
-
 INCLUDE = -I../include -I../
 
 TEST_SRCS = test_esl.c \
@@ -23,24 +21,13 @@ TEST_SRCS = test_esl.c \
 _LDFLAGS = $(LDFLAGS) -lcrypto -lstb-secvar-openssl -L$(LIB_DIR)
 _CFLAGS += $(CFLAGS) $(INCLUDE)
 
-TEST_OBJ = $(TEST_SRCS:.c=.o)
+BINS = $(patsubst %.c,$(BIN_DIR)/%,$(TEST_SRCS))
 
-all: $(patsubst %.c,$(BIN_DIR)/%,$(TEST_SRCS))
+all: $(BINS)
+check: $(patsubst test_%.c,%-check,$(TEST_SRCS))
 
-check: all
-ifeq ($(strip $(STATIC_LIB)), 1)
-	@$(BIN_DIR)/test_esl
-	@$(BIN_DIR)/test_auth2
-	@$(BIN_DIR)/test_update
-	@$(BIN_DIR)/test_pseries
-	@$(BIN_DIR)/test_phyp
-else
-	@LD_LIBRARY_PATH=$(LIB_DIR) $(BIN_DIR)/test_esl
-	@LD_LIBRARY_PATH=$(LIB_DIR) $(BIN_DIR)/test_auth2
-	@LD_LIBRARY_PATH=$(LIB_DIR) $(BIN_DIR)/test_update
-	@LD_LIBRARY_PATH=$(LIB_DIR) $(BIN_DIR)/test_pseries
-	@LD_LIBRARY_PATH=$(LIB_DIR) $(BIN_DIR)/test_phyp
-endif
+%-check: $(BIN_DIR)/test_%
+	@LD_LIBRARY_PATH=$(LIB_DIR) $<
 
 cppcheck:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,32 +14,18 @@ STATIC_LIB = 0
 
 INCLUDE = -I../include -I../
 
-TEST_SRCS = ./test_esl.c \
-            ./test_auth2.c \
-            ./test_update.c \
-            ./test_pseries.c \
-            ./test_phyp.c
+TEST_SRCS = test_esl.c \
+            test_auth2.c \
+            test_update.c \
+            test_pseries.c \
+            test_phyp.c
 
 _LDFLAGS = $(LDFLAGS) -lcrypto -lstb-secvar-openssl -L$(LIB_DIR)
 _CFLAGS += $(CFLAGS) $(INCLUDE)
 
 TEST_OBJ = $(TEST_SRCS:.c=.o)
 
-all: dirmake test_esl test_auth2 test_update test_pseries test_phyp
-
-ifeq ($(strip $(STATIC_LIB)), 1)
-  ifeq ($(wildcard $(LIB_DIR)/*.a),)
-	  @$(MAKE) -C ../ STATIC_LIB=$(STATIC_LIB)
-  endif
-else
-  ifeq ($(wildcard $(LIB_DIR)/*.so),)
-	  @$(MAKE) -C ../ STATIC_LIB=$(STATIC_LIB)
-  endif
-endif
-	@echo "libstb-secvar test Build successful!"
-
-dirmake:
-	@mkdir -p $(BIN_DIR)
+all: $(patsubst %.c,$(BIN_DIR)/%,$(TEST_SRCS))
 
 check: all
 ifeq ($(strip $(STATIC_LIB)), 1)
@@ -64,23 +50,9 @@ cppcheck-be:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \
 	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(TEST_SRCS) $(INCLUDE)
 
-test_esl: test_esl.o
-	$(CC) test_esl.o $(_LDFLAGS) -o $(BIN_DIR)/$@
-
-test_auth2: test_auth2.o
-	$(CC) test_auth2.o $(_LDFLAGS) -o $(BIN_DIR)/$@
-
-test_update: test_update.o
-	$(CC) test_update.o $(_LDFLAGS) -o $(BIN_DIR)/$@
-
-test_pseries: test_pseries.o
-	$(CC) test_pseries.o $(_LDFLAGS) -o $(BIN_DIR)/$@
-
-test_phyp: test_phyp.o
-	$(CC) test_phyp.o $(_LDFLAGS) -o $(BIN_DIR)/$@
-
-%.o: %.c
-	$(CC) $(_CFLAGS) $< -o $@ -c
+$(BIN_DIR)/test_%: test_%.c
+	@mkdir -p $(BIN_DIR)
+	$(CC) -o $@ $(_LDFLAGS) $(_CFLAGS) $^
 
 clean:
 	find ./ -name "*.[od]" -delete

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,7 @@ check: $(patsubst test_%.c,%-check,$(TEST_SRCS))
 
 $(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
 	@mkdir -p $(BIN_DIR)
-	$(CC) -o $@ $(_LDFLAGS) $(_CFLAGS) $^
+	$(CC) -o $@ $^ $(_LDFLAGS) $(_CFLAGS)
 
 cppcheck:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \

--- a/test/Makefile
+++ b/test/Makefile
@@ -42,7 +42,6 @@ $(BIN_DIR)/test_%: test_%.c
 	$(CC) -o $@ $(_LDFLAGS) $(_CFLAGS) $^
 
 clean:
-	find ./ -name "*.[od]" -delete
 	rm -rf $(BIN_DIR)
 
 .PHONY: all check cppcheck cppecheck-be clean

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ TEST_SRCS = test_esl.c \
             test_pseries.c \
             test_phyp.c
 
-_LDFLAGS = $(LDFLAGS) -lcrypto -lstb-secvar-openssl -L$(LIB_DIR)
+_LDFLAGS = $(LDFLAGS) -lcrypto
 _CFLAGS += $(CFLAGS) $(INCLUDE)
 
 BINS = $(patsubst %.c,$(BIN_DIR)/%,$(TEST_SRCS))
@@ -27,7 +27,7 @@ all: $(BINS)
 check: $(patsubst test_%.c,%-check,$(TEST_SRCS))
 
 %-check: $(BIN_DIR)/test_%
-	@LD_LIBRARY_PATH=$(LIB_DIR) $<
+	@$<
 
 cppcheck:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \
@@ -37,7 +37,7 @@ cppcheck-be:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \
 	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(TEST_SRCS) $(INCLUDE)
 
-$(BIN_DIR)/test_%: test_%.c
+$(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
 	@mkdir -p $(BIN_DIR)
 	$(CC) -o $@ $(_LDFLAGS) $(_CFLAGS) $^
 


### PR DESCRIPTION
This PR overhauls how we build libstb-secvar to be more friendly to partial builds, reuse of logic, and use of Makefile targets over environment variables.

The most notable changes off the top of my head are:
 - use wildcard rules everywhere possible
 - have separate build targets for `libstb-secvar.so` and `libstb-secvar.a`, have `all` depend on both
 - have defined source directories, and object directories
   - `obj/` contains `*.o` object files 
   - `lib/` contains the output `.so` and `.a` libraries
   - `test/bin/` contains the test binaries
 - use dependencies to run smaller Make targets over one Make target with several steps
   - e.g. have `make check` depend on `test-esl-check` which depends on building `test/bin/test_esl`, etc
 
Hopefully the commits are small enough to follow the logic, otherwise feel free to review the changed files wholesale. This is probably the most invasive overhaul of the upcoming PRs.
