### PR TITLE
Implement CI Checks via GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: tests
+
+on: ['push', 'pull_request']
+
+jobs:
+  unit-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: install test dependencies
+      run: sudo apt update && sudo apt install -y libssl-dev
+    - name: build libraries
+      run: make
+    - name: build tests
+      run: make tests
+    - name: run tests
+      run: make check
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt update && sudo apt install -y libssl-dev cppcheck clang-tools clang valgrind
+    - name: run scan-build
+      run: make clean && scan-build make
+    - name: run cppcheck
+      run: make cppcheck
+    - name: run valgrind
+      run: make memcheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib/
 obj/
 test/bin/
+report/

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 # Coverage objects
 $(OBJ_DIR)/%.gcov.o: $(SRC_DIR)/%.c
 	@mkdir -p $(OBJ_DIR)
-	$(CC) -Wall -Werror -g -O0 --coverage $(INCLUDE) $< -o $@ -c
+	$(CC) -Wall -Werror -g -O0 --coverage -DNO_PRLOG $(INCLUDE) $< -o $@ -c
 
 $(LIB_DIR)/libstb-secvar-openssl.a: $(OBJS)
 	@mkdir -p $(LIB_DIR)

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ tests: $(LIB_DIR)/libstb-secvar-openssl.a
 check: $(LIB_DIR)/libstb-secvar-openssl.a
 	@$(MAKE) -C $(TEST_DIR) check
 
+memcheck: $(LIB_DIR)/libstb-secvar-openssl.a
+	@$(MAKE) -C $(TEST_DIR) memcheck
+
 cppcheck:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force  \
 	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(SRCS) $(INCLUDE) \

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,15 @@ check: $(LIB_DIR)/libstb-secvar-openssl.a
 	@$(MAKE) -C $(TEST_DIR) check
 
 cppcheck:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force \
-	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(SRCS) $(INCLUDE)
+	cppcheck --enable=all --suppress=missingIncludeSystem --force  \
+	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(SRCS) $(INCLUDE) \
+			 --error-exitcode=1 -q
 	@$(MAKE) -C $(TEST_DIR) cppcheck
 
 cppcheck-be:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force \
-	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(SRCS) $(INCLUDE)
+	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(SRCS) $(INCLUDE)   \
+			 --error-exitcode=1 -q
 	@$(MAKE) -C $(TEST_DIR) cppcheck-be
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -70,17 +70,22 @@ check: $(LIB_DIR)/libstb-secvar-openssl.a
 memcheck: $(LIB_DIR)/libstb-secvar-openssl.a
 	@$(MAKE) -C $(TEST_DIR) memcheck
 
+TEST_SRCS = $(wildcard test/*.c)
+# variableScope: avoid reducing variable scope to maintain C compatibility
+# missingInclude: TODO: ideally rework all includes to make this unnecessary
+CPPCHECK_ARGS = --enable=all --force            \
+                --suppress=variableScope        \
+                --suppress=missingInclude       \
+                --error-exitcode=1 -q
 cppcheck:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force  \
-	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(SRCS) $(INCLUDE) \
-			 --error-exitcode=1 -q
-	@$(MAKE) -C $(TEST_DIR) cppcheck
+	cppcheck $(CPPCHECK_ARGS)                    \
+             -D__BYTE_ORDER__=__LITTLE_ENDIAN__  \
+             $(INCLUDE) $(SRCS) $(TEST_SRCS)
 
 cppcheck-be:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force \
-	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(SRCS) $(INCLUDE)   \
-			 --error-exitcode=1 -q
-	@$(MAKE) -C $(TEST_DIR) cppcheck-be
+	cppcheck $(CPPCHECK_ARGS)                \
+             -D__BYTE_ORDER__=__BIG_ENDIAN__ \
+             $(INCLUDE) $(SRCS) $(TEST_SRCS)
 
 clean:
 	@$(MAKE) -C $(TEST_DIR) clean

--- a/include/log.h
+++ b/include/log.h
@@ -20,6 +20,7 @@
 
 extern int libstb_log_level;
 
+#ifndef NO_PRLOG
 #define prlog(l, ...)                                             \
   do                                                              \
     {                                                             \
@@ -27,5 +28,8 @@ extern int libstb_log_level;
         fprintf ((l <= PR_ERR) ? stderr : stdout, ##__VA_ARGS__); \
     }                                                             \
   while (0)
+#else
+#define prlog(l, ...)
+#endif
 
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,9 +25,13 @@ BINS = $(patsubst %.c,$(BIN_DIR)/%,$(TEST_SRCS))
 
 all: $(BINS)
 check: $(patsubst test_%.c,%-check,$(TEST_SRCS))
+memcheck: $(patsubst test_%.c,%-memcheck,$(TEST_SRCS))
 
 %-check: $(BIN_DIR)/test_%
 	@$<
+
+%-memcheck: $(BIN_DIR)/test_%
+	@valgrind --leak-check=full --error-exitcode=1 -q $<
 
 $(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
 	@mkdir -p $(BIN_DIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,12 +34,14 @@ $(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
 	$(CC) -o $@ $^ $(_LDFLAGS) $(_CFLAGS)
 
 cppcheck:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force \
-	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(TEST_SRCS) $(INCLUDE)
+	cppcheck --enable=all --suppress=missingIncludeSystem --force       \
+	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(TEST_SRCS) $(INCLUDE) \
+			 --error-exitcode=1 -q
 
 cppcheck-be:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force \
-	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(TEST_SRCS) $(INCLUDE)
+	cppcheck --enable=all --suppress=missingIncludeSystem --force    \
+	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(TEST_SRCS) $(INCLUDE) \
+			 --error-exitcode=1 -q
 
 clean:
 	rm -rf $(BIN_DIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,16 +37,6 @@ $(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
 	@mkdir -p $(BIN_DIR)
 	$(CC) -o $@ $^ $(_LDFLAGS) $(_CFLAGS)
 
-cppcheck:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force       \
-	         -D__BYTE_ORDER__=__LITTLE_ENDIAN__ $(TEST_SRCS) $(INCLUDE) \
-			 --error-exitcode=1 -q
-
-cppcheck-be:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force    \
-	         -D__BYTE_ORDER__=__BIG_ENDIAN__ $(TEST_SRCS) $(INCLUDE) \
-			 --error-exitcode=1 -q
-
 clean:
 	rm -rf $(BIN_DIR)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,6 +26,7 @@ BINS = $(patsubst %.c,$(BIN_DIR)/%,$(TEST_SRCS))
 all: $(BINS)
 check: $(patsubst test_%.c,%-check,$(TEST_SRCS))
 memcheck: $(patsubst test_%.c,%-memcheck,$(TEST_SRCS))
+coverage: $(patsubst test_%.c,%-coverage,$(TEST_SRCS))
 
 %-check: $(BIN_DIR)/test_%
 	@$<
@@ -33,11 +34,20 @@ memcheck: $(patsubst test_%.c,%-memcheck,$(TEST_SRCS))
 %-memcheck: $(BIN_DIR)/test_%
 	@valgrind --leak-check=full --error-exitcode=1 -q $<
 
+%-coverage: $(BIN_DIR)/test_gcov_%
+	@$<
+
+.PRECIOUS: $(BIN_DIR)/test_%
 $(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.a
 	@mkdir -p $(BIN_DIR)
 	$(CC) -o $@ $^ $(_LDFLAGS) $(_CFLAGS)
 
+.PRECIOUS: $(BIN_DIR)/test_gcov_%
+$(BIN_DIR)/test_gcov_%: test_%.c $(LIB_DIR)/libstb-secvar-openssl.gcov.a
+	@mkdir -p $(BIN_DIR)
+	$(CC) -o $@ $^ $(_LDFLAGS) -Wall -Werror -g -O0 --coverage $(INCLUDE)
+
 clean:
 	rm -rf $(BIN_DIR)
 
-.PHONY: all check cppcheck cppecheck-be clean
+.PHONY: all check cppcheck cppecheck-be clean coverage


### PR DESCRIPTION
Depends on #6 and #7, merge those first.

Add GitHub Actions support for the following:
 - automatic test case running
 - static analysis via `cppcheck`
 - static analysis via LLVM's `scan-build`
 - memory checking via `valgrind`

Also includes coverage testing via `gcov`, and helper targets for generating reports via `gcovr` or `lcov`. Coverage testing is not currently handled by Actions, I will be investigating a solution in the future that does not depend on us using some external service. For now, run these and inspect the generated reports manually.
 