### PR TITLE
Include endian.h directly in common.h

### DIFF
--- a/external/edk2/common.h
+++ b/external/edk2/common.h
@@ -47,6 +47,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "config.h"
+#include "external/endian/endian.h"
 
 #define MAX_HASH_SIZE 32
 #define UUID_SIZE 16

--- a/external/edk2/common.h
+++ b/external/edk2/common.h
@@ -333,7 +333,7 @@ typedef struct auth_data auth_data_t;
 typedef struct update_request update_req_t;
 
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
-static const uint8_t defined_sb_variables [9] [12] = { "PK", "KEK", "db", "dbx", "grubdb",
+static const char defined_sb_variables [9] [12] = { "PK", "KEK", "db", "dbx", "grubdb",
                                                        "grubdbx", "sbat", "moduledb",
                                                        "trustedcadb"
                                                      };


### PR DESCRIPTION
common.h uses types such as leint32_t, which are defined in the ccan endian.h file. When building libstb-secvar standalone, other includes *usually* satisfy this requirement, but when including "common.h" in another project (i.e. secvarctl), these headers are no longer sufficient.

Include endian.h in common.h so that the requirement is made explicit. This may require some reconfiguring/repathing of header includes at some point.

Note: this (probably) does not depend on #7 or #8, so this can be merged whenever.