### PR TITLE
Fix missing _CFLAGS in coverage build compiler lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 # Coverage objects
 $(OBJ_DIR)/%.gcov.o: $(SRC_DIR)/%.c
 	@mkdir -p $(OBJ_DIR)
-	$(CC) -Wall -Werror -g -O0 --coverage -DNO_PRLOG $(INCLUDE) $< -o $@ -c
+	$(CC) $(_CFLAGS) -Wall -Werror -g -O0 --coverage -DNO_PRLOG $< -o $@ -c
 
 $(LIB_DIR)/libstb-secvar-$(CRYPTO_LIB).a: $(OBJS)
 	@mkdir -p $(LIB_DIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -52,7 +52,7 @@ $(BIN_DIR)/test_%: test_%.c $(LIB_DIR)/libstb-secvar-$(CRYPTO_LIB).a
 .PRECIOUS: $(BIN_DIR)/test_gcov_%
 $(BIN_DIR)/test_gcov_%: test_%.c $(LIB_DIR)/libstb-secvar-$(CRYPTO_LIB).gcov.a
 	@mkdir -p $(BIN_DIR)
-	$(CC) -o $@ $^ $(_LDFLAGS) -Wall -Werror -g -O0 --coverage $(INCLUDE)
+	$(CC) -o $@ $^ $(_LDFLAGS) $(_CFLAGS) -Wall -Werror -g -O0 --coverage
 
 clean:
 	rm -rf $(BIN_DIR)


### PR DESCRIPTION
For some reason, coverage build objects did not use $(_CFLAGS) in their CC line, therefore not building with the proper CRYPTO_LIB flag.